### PR TITLE
Compare semver of package.json vs shrinkwrap

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -3,6 +3,8 @@
 var diff = require('array-difference'),
     fs = require('fs'),
     optimist = require('optimist'),
+    semver = require('semver'),
+    semverSatisfied = true,
     argv,
     packageJSON,
     shrinkwrapJSON,
@@ -32,8 +34,10 @@ argv = optimist
   .usage('Ensure package.json and npm-shrinkwrap.json are in sync')
   .alias('d', 'dev')
   .alias('h', 'help')
+  .alias('s', 'semver')
   .describe('d', 'Check devDependencies')
   .describe('h', 'Show this help message')
+  .describe('s', 'Check semver')
   .argv;
 
 if (argv.help) {
@@ -83,4 +87,17 @@ if (depDiff.length) {
   });
 }
 
-process.exit(+(depDiff.length !== 0));
+if (argv.semver) {
+  packageDeps.forEach(function(dependency) {
+    var range = packageJSON.dependencies[dependency] ||
+          (argv.dev && packageJSON.devDependencies[dependency]);
+    var version = (shrinkwrapJSON.dependencies[dependency] || {}).version;
+
+    if (version && semver.validRange(range) && !semver.satisfies(version, range)) {
+      semverSatisfied = false;
+      process.stderr.write(' * ' + dependency + '@' + version + ' in npm-shrinkwrap.json does not satisfy range ' + range + ' in package.json\n');
+    }
+  });
+}
+
+process.exit(+(depDiff.length !== 0 || !semverSatisfied));

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "array-difference": "0.0.1",
-    "optimist": "^0.6.1"
+    "optimist": "^0.6.1",
+    "semver": "^5.0.3"
   }
 }


### PR DESCRIPTION
This enables ensuring a dependency's semver range in `package.json` is satisfied by `version` in from `npm-shrinkwrap.json`.

Scenario:

``` sh
npm install --save abc@1.0.0
npm shrinkwrap
npm install --save abc@2.0.0
# npm-shrinkwrap.json dependency names match up, but versions don't
```
