### PR TITLE
Ignore package.json files outside package roots

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -71,7 +71,7 @@ if (npm_major_version === '3' && !argv.v3) {
 
 // for npm@3
 if (argv.v3) {
-  glob.sync(process.cwd() + "/node_modules/**/package.json").forEach(function(pkgPath) {
+  glob.sync(process.cwd() + "/**/node_modules/*/package.json").forEach(function(pkgPath) {
     var pkg = loadJSON(pkgPath);
     var deps = Object.keys(pkg.dependencies || []);
     packageDeps = packageDeps.concat(deps);


### PR DESCRIPTION
This prevents false negatives arising from package.json files that are nested inside dependencies for whatever reason.

For example, the [asn1.js](https://github.com/indutny/asn1.js) package includes two nested package.json files ([here](https://github.com/indutny/asn1.js/tree/master/rfc/2560) and [here](https://github.com/indutny/asn1.js/tree/master/rfc/5280)), which end up incorrectly being used as sources of dependencies for `packageDeps`.
