### PR TITLE
Don't fail checks if a package.json without dependencies is encountered

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -56,11 +56,13 @@ argv = optimist
   .alias('3', 'v3')
   .alias('v', 'verbose')
   .alias('V', 'version')
+  .alias('a', 'allowEmpty')
   .describe('3', 'Perform check taking npm3 flat structure into account.')
   .describe('d', 'Check devDependencies.')
   .describe('h', 'Show this help message.')
   .describe('v', 'Run in verbose mode')
   .describe('V', 'Outputs version')
+  .describe('a', 'Allow empty or dummy package.json files')
   .argv;
 
 if (argv.version) {
@@ -90,6 +92,12 @@ packagePeerDeps = readKeys(packageJSON.peerDependencies);
 
 glob.sync(process.cwd() + "/**/node_modules/*/package.json").forEach(function(pkgPath) {
   var pkg = loadJSON(pkgPath);
+  
+  // bail out in case we encounter a dummy package.json
+  if (argv.allowEmpty && (!pkg || !pkg.dependencies)) {
+      return;
+  }
+  
   var thisPackageDeps = readKeys(pkg.dependencies);
   var isValidPath = every(
                       pkgPath

--- a/bin/cli
+++ b/bin/cli
@@ -56,13 +56,11 @@ argv = optimist
   .alias('3', 'v3')
   .alias('v', 'verbose')
   .alias('V', 'version')
-  .alias('a', 'allowEmpty')
   .describe('3', 'Perform check taking npm3 flat structure into account.')
   .describe('d', 'Check devDependencies.')
   .describe('h', 'Show this help message.')
   .describe('v', 'Run in verbose mode')
   .describe('V', 'Outputs version')
-  .describe('a', 'Allow empty or dummy package.json files')
   .argv;
 
 if (argv.version) {
@@ -94,7 +92,7 @@ glob.sync(process.cwd() + "/**/node_modules/*/package.json").forEach(function(pk
   var pkg = loadJSON(pkgPath);
   
   // bail out in case we encounter a dummy package.json
-  if (argv.allowEmpty && (!pkg || !pkg.dependencies)) {
+  if (!pkg || !pkg.dependencies) {
       return;
   }
   

--- a/bin/cli
+++ b/bin/cli
@@ -92,6 +92,7 @@ glob.sync(process.cwd() + "/**/node_modules/*/package.json").forEach(function(pk
   var pkg = loadJSON(pkgPath);
   
   // bail out in case we encounter a dummy package.json
+  // or one with no dependencies
   if (!pkg || !pkg.dependencies) {
       return;
   }


### PR DESCRIPTION
Thanks for this great module! It just required one tweak so that I could use it, and I hope you'll consider upstreaming the fix.

The way `npm-shrinkwrap-check` works is to traverse your whole project looking for `package.json` files. It assumes each one of these contains a JSON object with a `dependencies` property. However, this is not true for all `package.json` files. 

For example, the node module `read-package-tree` contains this file: https://github.com/npm/read-package-tree/blob/master/test/fixtures/empty/node_modules/foo/package.json
This gets picked up by `npm-shrinkwrap-check` and an error is thrown because `pkg.dependencies` is undefined.

My fix simply returns early in the dependency gathering stage if the `pkg` object does not have the right shape for our purposes.
