### PR TITLE
Add the actual package to the packageDeps in npm3 mode

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -112,6 +112,10 @@ glob.sync(process.cwd() + "/**/node_modules/*/package.json", {follow: true}).for
 
   if (argv.v3) {
     packageDeps = packageDeps.concat(thisPackageDeps);
+
+    if (!!pkg.name) {
+      packageDeps = packageDeps.concat(pkg.name);
+    }
   }
 
   foundOptionalDeps = foundOptionalDeps.concat(thisPackageOptionalDeps);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-shrinkwrap-check",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Checks that package.json and npm-shrinkwrap.json are always in sync.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What?

When using in npm 3 mode, the dependencies being generated weren't including the actual package itself. Amazingly, between all the interdeps and after all the deps were generated pure coincidence meant that the list of deps to be compared with those of npm shrinkwrap actually contained all the required dependencies. But not always...

This PR fixes that and ensure that the actual package itself is also added to the package deps list.
### Merits

@Morantron 99.9% :)
### Gif

![](https://media.giphy.com/media/tSYbqPjyOb84w/giphy.gif)
