### PR TITLE
The packages under test directory is invalid

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -96,7 +96,13 @@ glob.sync(process.cwd() + "/**/node_modules/*/package.json", {follow: true}).for
                         .replace(process.cwd(), '')
                         .replace(/^\//, '')
                         .split('/').map(function (segment, i) {
-                          return segment === 'node_modules' ? i % 2 === 0 : true
+                          if (segment === 'test') {
+                            return false;
+                          }
+                          if (segment === 'node_modules') {
+                            return i % 2 === 0;
+                          }
+                          return true;
                         })
                     );
 


### PR DESCRIPTION
The packages under test directory is invalid. For example: https://github.com/substack/node-browserify/tree/6df33e5cb0e9110f7656bf07109f245170df5a19/test/ignore_browser_field/node_modules

If this package becomes the target, it will be error output is displayed below.

``` sh
package.json and npm-shrinkwrap.json out of sync
 * a found in package.json but not in npm-shrinkwrap.json
 * b found in package.json but not in npm-shrinkwrap.json
```
